### PR TITLE
docs: document asset imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ export default {
 };
 ```
 
+### Importing assets
+
+Static assets exposed by the package can be imported like any other module. This lets bundlers include images or fonts alongside your code:
+
+```javascript
+import logo from '@SivaG2025/flw-theme/assets/logo.png';
+```
+
 ### Overriding tokens
 
 The package exposes design tokens as CSS variables. You can override any token by redefining it after importing `base.css`.


### PR DESCRIPTION
## Summary
- document how to import static assets from the theme package

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e69e22483339f2affd4874bddaa